### PR TITLE
getOptions > refactor code for reuse through multiple ESLibs

### DIFF
--- a/src/_index.js
+++ b/src/_index.js
@@ -1,3 +1,5 @@
+import {getOptions} from "@/helpers";
+
 /**
  * Private class
  */
@@ -75,7 +77,7 @@ class Popup{
         this.options.hasMobileLayout = this.isBooleanOptionTrue(this.attributes.mobileLayout, this.options.hasMobileLayout);
 
         // get options from JSON init
-        this.getOptions();
+        getOptions(this);
 
         this.closeButtonHTML = this.options.closeButtonHTML;
         this.masterContainer = document.querySelector(`.${this.classes.master}`);
@@ -105,65 +107,6 @@ class Popup{
     isBooleanOptionTrue(attr, option){
         const attrValue = this.el.getAttribute(attr);
         return attrValue ? attrValue !== 'false' : option;
-    }
-
-    getOptions(){
-        const numeric = ['autoShow']; // convert these props to float
-
-        // options from attribute
-        let dataAttribute = this.el.getAttribute(this.attributes.init);
-        let options = {
-            id: this.options.id,
-            title: this.options.title,
-            theme: this.options.theme,
-            clickOutsideToClose: this.options.clickOutsideToClose,
-            hasMobileLayout: this.options.hasMobileLayout
-        };
-
-        // not JSON format or not exist -> string
-        if(!dataAttribute || !this.isJSON(dataAttribute)){
-            this.id = dataAttribute || this.options.id;
-            return;
-        }
-
-        // option priority: attribute > js object > default
-        options = {...options, ...JSON.parse(dataAttribute)};
-
-
-        // convert
-        for(const [key, value] of Object.entries(options)){
-            // convert boolean string to real boolean
-            if(value === "false") options[key] = false;
-            else if(value === "true") options[key] = true;
-            else options[key] = value;
-
-            // convert string to float
-            if(numeric.includes(key) && typeof value === 'string'){
-                options[key] = parseFloat(value);
-            }
-        }
-
-
-        this.options = {...this.options, ...options};
-        this.id = options.id || this.options.id;
-
-        // remove json
-        this.el.removeAttribute(this.attributes.init);
-    }
-
-
-    /**
-     * Is JSON string
-     * https://stackoverflow.com/a/32278428/6453822
-     * @param string
-     * @returns {any|boolean}
-     */
-    isJSON(string){
-        try{
-            return (JSON.parse(string) && !!string);
-        }catch(e){
-            return false;
-        }
     }
 
     generateHTML(){

--- a/src/_index.js
+++ b/src/_index.js
@@ -77,7 +77,7 @@ class Popup{
         this.options.hasMobileLayout = this.isBooleanOptionTrue(this.attributes.mobileLayout, this.options.hasMobileLayout);
 
         // get options from JSON init
-        getOptions(this);
+        this.options = getOptions(this, this.options);
 
         this.closeButtonHTML = this.options.closeButtonHTML;
         this.masterContainer = document.querySelector(`.${this.classes.master}`);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,6 @@
 /**
  * Get JSON options
+ * @version 0.0.1
  * @returns void
  */
 export function getOptions(context){

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,54 @@
+/**
+ * Get JSON options
+ * @returns void
+ */
+export function getOptions(context){
+    const numeric = ['autoShow']; // convert these props to float
+    const wrapper = context.el;
+
+    // options from attribute
+    let dataAttribute = wrapper.getAttribute(context.attributes.init);
+    let options = {};
+
+    // data attribute doesn't exist or not JSON format -> get default ID
+    if(!dataAttribute || !isJSON(dataAttribute)){
+        context.id = dataAttribute || context.options.id;
+        return;
+    }
+
+    // option priority: attribute > js object > default
+    options = JSON.parse(dataAttribute);
+
+    for(const [key, value] of Object.entries(options)){
+        // convert boolean string to real boolean
+        if(value === "false") options[key] = false;
+        else if(value === "true") options[key] = true;
+        else options[key] = value;
+
+        // convert string to float
+        if(numeric.includes(key) && typeof value === 'string' && value.length > 0){
+            options[key] = parseFloat(value);
+        }
+    }
+
+    context.options = {...context.options, ...options};
+    context.id = options.id || context.options.id;
+
+    // remove json
+    wrapper.removeAttribute(context.attributes.init);
+}
+
+
+/**
+ * Is JSON string
+ * https://stackoverflow.com/a/32278428/6453822
+ * @param string
+ * @returns {any|boolean}
+ */
+export function isJSON(string){
+    try{
+        return (JSON.parse(string) && !!string);
+    }catch(e){
+        return false;
+    }
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,9 +40,6 @@ export function getOptions(context, defaultOptions){
 
     options = {...defaultOptions, ...options};
 
-    // remove json
-    wrapper.removeAttribute(context.attributes.init);
-
     return options;
 }
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,10 @@
 /**
  * Get JSON options
+ * ID priority: data-attribute > selector#id > unique id
  * @version 0.0.1
- * @returns void
+ * @returns {object}
  */
-export function getOptions(context){
+export function getOptions(context, defaultOptions){
     const numeric = ['autoShow']; // convert these props to float
     const wrapper = context.el;
 
@@ -11,32 +12,38 @@ export function getOptions(context){
     let dataAttribute = wrapper.getAttribute(context.attributes.init);
     let options = {};
 
-    // data attribute doesn't exist or not JSON format -> get default ID
+    // data attribute doesn't exist or not JSON format -> string
     if(!dataAttribute || !isJSON(dataAttribute)){
-        context.id = dataAttribute || context.options.id;
-        return;
+        // reassign id
+        const id = dataAttribute || wrapper.id || defaultOptions.id;
+        context.id = id;
+        defaultOptions.id = id;
+
+        return defaultOptions;
     }
 
-    // option priority: attribute > js object > default
     options = JSON.parse(dataAttribute);
 
     for(const [key, value] of Object.entries(options)){
         // convert boolean string to real boolean
         if(value === "false") options[key] = false;
         else if(value === "true") options[key] = true;
-        else options[key] = value;
-
         // convert string to float
-        if(numeric.includes(key) && typeof value === 'string' && value.length > 0){
-            options[key] = parseFloat(value);
-        }
+        else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
+        else options[key] = value;
     }
 
-    context.options = {...context.options, ...options};
-    context.id = options.id || context.options.id;
+    // reassign id
+    const id = options.id || wrapper.id || defaultOptions.id;
+    context.id = id;
+    options.id = id;
+
+    options = {...defaultOptions, ...options};
 
     // remove json
     wrapper.removeAttribute(context.attributes.init);
+
+    return options;
 }
 
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -21,10 +21,11 @@ export function getOptions(context, defaultOptions){
 
     // data attribute is not json format or string
     if(attributeIsNotJSON){
-        options = defaultOptions;
+        options = {...defaultOptions};
 
         // data attribute exist => string
         if(dataAttribute) options.id = dataAttribute;
+        else options.id = '';
     }else{
         options = JSON.parse(dataAttribute);
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -5,6 +5,10 @@
  * @returns {object}
  */
 export function getOptions(context, defaultOptions){
+    if(!defaultOptions){
+        defaultOptions = context.options || context.config || {};
+    }
+
     const numeric = ['autoShow']; // convert these props to float
     const wrapper = context.el;
 
@@ -13,24 +17,25 @@ export function getOptions(context, defaultOptions){
     let options = {};
 
     // data attribute doesn't exist or not JSON format -> string
-    if(!dataAttribute || !isJSON(dataAttribute)){
-        // reassign id
-        const id = dataAttribute || wrapper.id || defaultOptions.id;
-        context.id = id;
-        defaultOptions.id = id;
+    const attributeIsNotJSON = !dataAttribute || !isJSON(dataAttribute);
 
-        return defaultOptions;
-    }
+    // data attribute is not json format or string
+    if(attributeIsNotJSON){
+        options = defaultOptions;
 
-    options = JSON.parse(dataAttribute);
+        // data attribute exist => string
+        if(dataAttribute) options.id = dataAttribute;
+    }else{
+        options = JSON.parse(dataAttribute);
 
-    for(const [key, value] of Object.entries(options)){
-        // convert boolean string to real boolean
-        if(value === "false") options[key] = false;
-        else if(value === "true") options[key] = true;
-        // convert string to float
-        else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
-        else options[key] = value;
+        for(const [key, value] of Object.entries(options)){
+            // convert boolean string to real boolean
+            if(value === "false") options[key] = false;
+            else if(value === "true") options[key] = true;
+            // convert string to float
+            else if(numeric.includes(key) && typeof value === 'string' && value.length > 0) options[key] = parseFloat(value);
+            else options[key] = value;
+        }
     }
 
     // reassign id


### PR DESCRIPTION
Write the same `getOptions` function for making our code reusable and using through multiple ES Libraries (or any library that needs to get options from data-attribute) :
- [Easy Tab Accordion](https://github.com/viivue/easy-tab-accordion)
- [Easy Select](https://github.com/viivue/easy-select)
- [Easy Popup](https://github.com/viivue/easy-popup)

With the new `getOptions` function, we can get options and override them for each library option through data-attribute