### PR TITLE
fix(outerClass): trim string to avoid adding empty class

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -32,7 +32,7 @@ export function generateHTML(context){
     context.outer = wrapElement(context.overflow);
     context.outer.classList.add(CLASSES.outer);
     if(context.options.outerClass){
-      const classes = context.options.outerClass.split(' ');
+        const classes = context.options.outerClass.trim().split(' ');
       for(let i = 0; i < classes.length; i++) context.outer.classList.add(classes[i])
     }
     context.outer.setAttribute(ATTRS.id, context.id);

--- a/src/html.js
+++ b/src/html.js
@@ -33,7 +33,7 @@ export function generateHTML(context){
     context.outer.classList.add(CLASSES.outer);
     if(context.options.outerClass){
         const classes = context.options.outerClass.trim().split(' ');
-      for(let i = 0; i < classes.length; i++) context.outer.classList.add(classes[i])
+        for(let i = 0; i < classes.length; i++) context.outer.classList.add(classes[i])
     }
     context.outer.setAttribute(ATTRS.id, context.id);
 


### PR DESCRIPTION
This pull request includes a small but important change to the `generateHTML` function in the `src/html.js` file. The change ensures that any leading or trailing whitespace in the `outerClass` option is removed before splitting it into individual class names.

* [`src/html.js`](diffhunk://#diff-023eb4be0e5096f5a778ef1dfee421162b529c473ad2c2c7f3e12534eeaa44b7L35-R35): Modified the `generateHTML` function to use `trim()` on `context.options.outerClass` before splitting it into classes.